### PR TITLE
fix: resolve cross-platform oauth runtime issues

### DIFF
--- a/OutlookRegister.py
+++ b/OutlookRegister.py
@@ -1,13 +1,25 @@
-import os
 import time
 import json
 import random
 import string
 import secrets
+from pathlib import Path
 from faker import Faker
 from get_token import get_access_token
 from playwright.sync_api import sync_playwright
 from concurrent.futures import ThreadPoolExecutor
+
+RESULTS_DIR = Path("Results")
+
+def append_result_line(filename, line):
+    target = RESULTS_DIR / filename
+    with target.open('a', encoding='utf-8') as handle:
+        handle.write(line)
+
+
+def get_remaining_wait_ms(start_time):
+    elapsed_ms = (time.time() - start_time) * 1000
+    return max(0, bot_protection_wait - elapsed_ms)
 
 def generate_strong_password(length=16):
 
@@ -38,21 +50,24 @@ def random_email(length):
 def OpenBrowser():
     try:
         p = sync_playwright().start()
-        browser = p.chromium.launch(
-            executable_path=browser_path,
-            headless=False,
-            args=[
-                '--lang=zh-CN'
-            ],
-            proxy={
+        launch_kwargs = {
+            "headless": False,
+            "args": ['--lang=zh-CN'],
+        }
+        if browser_path:
+            launch_kwargs["executable_path"] = browser_path
+        if proxy:
+            launch_kwargs["proxy"] = {
                 "server": proxy,
                 "bypass": "localhost",
-            },
-        ) 
-        return browser,p
+            }
+
+        browser = p.chromium.launch(**launch_kwargs)
+        return browser, p
 
     except Exception as e:
-        print(e)
+        print(f"启动浏览器失败: {type(e).__name__}: {e}")
+        return None, None
 
 def Outlook_register(page, email, password):
 
@@ -112,7 +127,7 @@ def Outlook_register(page, email, password):
         page.locator('#firstNameInput').fill(firstname,timeout=10000)
 
         if time.time() - start_time < bot_protection_wait / 1000:
-            page.wait_for_timeout(bot_protection_wait - (time.time() + start_time) * 1000)
+            page.wait_for_timeout(get_remaining_wait_ms(start_time))
         
         page.locator('[data-testid="primaryButton"]').click(timeout=5000)
         page.locator('span > [href="https://go.microsoft.com/fwlink/?LinkID=521839"]').wait_for(state='detached',timeout=22000)
@@ -175,9 +190,8 @@ def Outlook_register(page, email, password):
         print(f"[Error: IP] - 加载超时或因触发机器人检测导致按压次数达到最大仍未通过。")
         return False 
 
-    filename = 'Results\\logged_email.txt' if enable_oauth2 else 'Results\\unlogged_email.txt'
-    with open(filename, 'a', encoding='utf-8') as f:
-        f.write(f"{email}@outlook.com: {password}\n")
+    filename = 'logged_email.txt' if enable_oauth2 else 'unlogged_email.txt'
+    append_result_line(filename, f"{email}@outlook.com: {password}\n")
     print(f'[Success: Email Registration] - {email}@outlook.com: {password}')
 
     if not enable_oauth2:
@@ -211,9 +225,13 @@ def Outlook_register(page, email, password):
 
 def process_single_flow():
 
+    browser = None
+    p = None
     try:
-        browser = None
         browser, p = OpenBrowser()
+        if not browser or not p:
+            return False
+
         page = browser.new_page()
 
         email =  random_email(random.randint(12, 14))
@@ -226,22 +244,27 @@ def process_single_flow():
         elif not result:
             return False
         
-        token_result = get_access_token(page, email)
+        token_result = get_access_token(page, email, proxy)
         if token_result[0]:
             refresh_token, access_token, expire_at =  token_result
-            with open(r'Results\outlook_token.txt', 'a') as f2:
-                f2.write(email + "@outlook.com---" + password + "---" + refresh_token + "---" + access_token  + "---" + str(expire_at) + "\n") 
+            append_result_line(
+                "outlook_token.txt",
+                email + "@outlook.com---" + password + "---" + refresh_token + "---" + access_token  + "---" + str(expire_at) + "\n",
+            )
             print(f'[Success: TokenAuth] - {email}@outlook.com')
             return True
         else:
             return False
 
-    except:
+    except Exception as exc:
+        print(f"单任务执行失败: {type(exc).__name__}: {exc}")
         return False
     
     finally:
-        browser.close()
-        p.stop()
+        if browser is not None:
+            browser.close()
+        if p is not None:
+            p.stop()
 
 def main(concurrent_flows=10, max_tasks=1000):
 
@@ -285,7 +308,7 @@ if __name__ == '__main__':
     with open('config.json', 'r', encoding='utf-8') as f:
         data = json.load(f) 
 
-    os.makedirs("Results", exist_ok=True)
+    RESULTS_DIR.mkdir(exist_ok=True)
 
     browser_path = data['browser_path']
     bot_protection_wait = data['Bot_protection_wait'] * 1000

--- a/OutlookRegister_patchright.py
+++ b/OutlookRegister_patchright.py
@@ -1,10 +1,10 @@
-import os
 import time
 import json
 import random
 import string
 import secrets
 import threading
+from pathlib import Path
 from faker import Faker
 from get_token import get_access_token
 from patchright.sync_api import sync_playwright
@@ -21,6 +21,17 @@ thread_local = threading.local()
 cleanup_lock = threading.Lock()
 active_browsers = []
 active_playwrights = []
+RESULTS_DIR = Path("Results")
+
+def append_result_line(filename, line):
+    target = RESULTS_DIR / filename
+    with target.open('a', encoding='utf-8') as handle:
+        handle.write(line)
+
+
+def get_remaining_wait_ms(start_time):
+    elapsed_ms = (time.time() - start_time) * 1000
+    return max(0, bot_protection_wait - elapsed_ms)
 
 def generate_strong_password(length=16):
 
@@ -136,7 +147,7 @@ def Outlook_register(page, email, password):
         page.locator('#firstNameInput').fill(firstname,timeout=10000)
 
         if time.time() - start_time < bot_protection_wait / 1000:
-            page.wait_for_timeout(bot_protection_wait - (time.time() + start_time) * 1000)
+            page.wait_for_timeout(get_remaining_wait_ms(start_time))
         
         page.locator('[data-testid="primaryButton"]').click(timeout=5000)
         page.locator('span > [href="https://go.microsoft.com/fwlink/?LinkID=521839"]').wait_for(state='detached',timeout=22000)
@@ -191,9 +202,8 @@ def Outlook_register(page, email, password):
         print(f"[Error: IP] - 加载超时或因触发机器人检测导致按压次数达到最大仍未通过。")
         return False 
 
-    filename = 'Results\\logged_email.txt' if enable_oauth2 else 'Results\\unlogged_email.txt'
-    with open(filename, 'a', encoding='utf-8') as f:
-        f.write(f"{email}@outlook.com: {password}\n")
+    filename = 'logged_email.txt' if enable_oauth2 else 'unlogged_email.txt'
+    append_result_line(filename, f"{email}@outlook.com: {password}\n")
     print(f'[Success: Email Registration] - {email}@outlook.com: {password}')
 
     if not enable_oauth2:
@@ -245,17 +255,20 @@ def process_single_flow():
         elif not result:
             return False
 
-        token_result = get_access_token(page, email)
+        token_result = get_access_token(page, email, proxy)
         if token_result[0]:
             refresh_token, access_token, expire_at =  token_result
-            with open(r'Results\outlook_token.txt', 'a') as f2:
-                f2.write(f"{email}@outlook.com---{password}---{refresh_token}---{access_token}---{expire_at}\n") 
+            append_result_line(
+                "outlook_token.txt",
+                f"{email}@outlook.com---{password}---{refresh_token}---{access_token}---{expire_at}\n",
+            )
             print(f'[Success: TokenAuth] - {email}@outlook.com')
             return True
         else:
             return False
 
-    except:
+    except Exception as exc:
+        print(f"单任务执行失败: {type(exc).__name__}: {exc}")
         return False
     
     finally:
@@ -313,7 +326,7 @@ if __name__ == '__main__':
     with open('config.json', 'r', encoding='utf-8') as f:
         data = json.load(f) 
 
-    os.makedirs("Results", exist_ok=True)
+    RESULTS_DIR.mkdir(exist_ok=True)
 
     bot_protection_wait = data['Bot_protection_wait'] * 1000
     max_captcha_retries = data['max_captcha_retries']

--- a/get_token.py
+++ b/get_token.py
@@ -1,27 +1,102 @@
-import json
 import base64
-import random
-import string
-import winreg
 import hashlib
+import json
 import secrets
-import requests
+import threading
 from datetime import datetime
-from urllib.parse import quote, parse_qs
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, quote, urlparse
 
-def get_proxy():
+import requests
+
+try:
+    import winreg  # type: ignore
+except ImportError:
+    winreg = None
+
+
+class OAuthCallbackServer:
+    """本地 OAuth 回调接收器，仅用于 localhost/127.0.0.1。"""
+
+    def __init__(self, redirect_url):
+        parsed = urlparse(redirect_url)
+        if parsed.scheme != "http" or parsed.hostname not in {"localhost", "127.0.0.1"}:
+            raise ValueError("仅支持 http://localhost 或 http://127.0.0.1 回调地址")
+
+        self.expected_path = parsed.path or "/"
+        self.bind_host = parsed.hostname
+        self.bind_port = parsed.port or 80
+        self.callback_url = None
+        self._callback_event = threading.Event()
+
+        parent = self
+
+        class CallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                request = urlparse(self.path)
+                if request.path != parent.expected_path:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write("Not Found".encode("utf-8"))
+                    return
+
+                host = self.headers.get("Host") or f"{parent.bind_host}:{parent.bind_port}"
+                parent.callback_url = f"http://{host}{self.path}"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.end_headers()
+                self.wfile.write("授权成功，可关闭此页面。".encode("utf-8"))
+                parent._callback_event.set()
+
+            def log_message(self, format, *args):
+                return
+
+        self._server = ThreadingHTTPServer((self.bind_host, self.bind_port), CallbackHandler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def wait_for_callback(self, timeout):
+        if not self._callback_event.wait(timeout):
+            return None
+        return self.callback_url
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def get_system_proxy():
+    """读取 Windows 系统代理；非 Windows 直接返回 None。"""
+    if winreg is None:
+        return None
+
     try:
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Internet Settings") as key:
             proxy_enable, _ = winreg.QueryValueEx(key, "ProxyEnable")
             proxy_server, _ = winreg.QueryValueEx(key, "ProxyServer")
             if proxy_enable and proxy_server:
                 return {"http": f"http://{proxy_server}", "https": f"http://{proxy_server}"}
-    except WindowsError:
-        pass
-    return {"http": None, "https": None}
+    except OSError:
+        return None
+
+    return None
+
+
+def build_requests_proxy(proxy_url=None):
+    """优先使用配置文件里的代理，避免浏览器链路和 requests 链路出口不一致。"""
+    if proxy_url:
+        return {"http": proxy_url, "https": proxy_url}
+    return get_system_proxy()
+
+
+def is_local_redirect_url(redirect_url):
+    parsed = urlparse(redirect_url)
+    return parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1"}
 
 def generate_code_verifier(length=128):
-    alphabet = string.ascii_letters + string.digits + '-._~'
+    alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'
     return ''.join(secrets.choice(alphabet) for _ in range(length))
 
 def generate_code_challenge(code_verifier):
@@ -35,16 +110,60 @@ def handle_oauth2_form(page,email):
         page.locator('#idSIButton9').click(timeout=7000)
         page.locator('[data-testid="appConsentPrimaryButton"]').click(timeout=20000)
 
-    except:
+    except Exception:
         pass
 
-def get_access_token(page, email):
+
+def build_authorize_url(params):
+    return f"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{'&'.join(f'{k}={quote(v)}' for k,v in params.items())}"
+
+
+def navigate_to_authorize(page, authorize_url, email):
+    max_time = 2
+    current_times = 0
+    while current_times < max_time:
+        try:
+            page.wait_for_timeout(250)
+            page.goto(authorize_url)
+            break
+        except Exception:
+            current_times += 1
+            if current_times == max_time:
+                return False
+
+    handle_oauth2_form(page, email)
+    return True
+
+
+def wait_for_redirect_callback(page, email, authorize_url, redirect_url):
+    """按 redirect_url 类型分别等待远端回调或本地 localhost 回调。"""
+    if is_local_redirect_url(redirect_url):
+        callback_server = OAuthCallbackServer(redirect_url)
+        try:
+            callback_server.start()
+            if not navigate_to_authorize(page, authorize_url, email):
+                return None
+            return callback_server.wait_for_callback(timeout=50)
+        finally:
+            callback_server.close()
+
+    with page.expect_response(lambda response: redirect_url in response.url, timeout=50000) as response_info:
+        if not navigate_to_authorize(page, authorize_url, email):
+            return None
+    return response_info.value.url
+
+
+def get_access_token(page, email, proxy_url=None):
 
     with open('config.json', 'r', encoding='utf-8') as f:
         data = json.load(f) 
     SCOPES = data['Scopes']
     client_id = data['client_id']
     redirect_url = data['redirect_url']
+
+    if not client_id or not redirect_url or not SCOPES:
+        print("OAuth2 配置缺失：请检查 client_id / redirect_url / Scopes")
+        return False, False, False
 
     code_verifier = generate_code_verifier()  
     code_challenge = generate_code_challenge(code_verifier) 
@@ -60,36 +179,22 @@ def get_access_token(page, email):
         'code_challenge_method': 'S256'
     }
 
-    with page.expect_response(lambda response: redirect_url in response.url,timeout=50000) as response_info:
+    authorize_url = build_authorize_url(params)
+    try:
+        callback_url = wait_for_redirect_callback(page, email, authorize_url, redirect_url)
+    except Exception as exc:
+        print(f"等待 OAuth 回调失败: {type(exc).__name__}: {exc}")
+        return False, False, False
 
-        max_time = 2 
-        current_times = 0
-        while current_times < max_time:
+    if not callback_url:
+        print("Authorization failed: OAuth 回调超时或未收到 code")
+        return False, False, False
 
-            try:
-
-                page.wait_for_timeout(250)
-                url = f"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{'&'.join(f'{k}={quote(v)}' for k,v in params.items())}"
-                page.goto(url)
-
-                break
-
-            except:
-                    current_times = current_times + 1 
-                    if current_times == max_time:
-                        return False, False, False
-                    continue
-            
-        handle_oauth2_form(page, email)
-
-        response = response_info.value
-        callback_url = response.url
-
-        if 'code=' not in callback_url:
-
-            print("Authorization failed: No code in callback URL")
-            return False, False, False
-        auth_code = parse_qs(callback_url.split('?')[1])['code'][0]
+    callback_query = parse_qs(urlparse(callback_url).query)
+    auth_code = callback_query.get('code', [None])[0]
+    if not auth_code:
+        print("Authorization failed: No code in callback URL")
+        return False, False, False
 
     token_data = {
         'client_id': client_id,
@@ -100,23 +205,32 @@ def get_access_token(page, email):
         'scope': ' '.join(SCOPES)
     }
 
-    response = requests.post('https://login.microsoftonline.com/common/oauth2/v2.0/token', data=token_data, headers={
-        'Content-Type': 'application/x-www-form-urlencoded'
-    }, proxies=get_proxy())
-
-    if 'refresh_token' in response.json():
-
+    try:
+        response = requests.post(
+            'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+            data=token_data,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            proxies=build_requests_proxy(proxy_url),
+            timeout=30,
+        )
         tokens = response.json()
-        token_data = {
+    except requests.RequestException as exc:
+        print(f"Token 请求失败: {type(exc).__name__}: {exc}")
+        return False, False, False
+    except ValueError as exc:
+        print(f"Token 响应不是合法 JSON: {type(exc).__name__}: {exc}")
+        return False, False, False
+
+    if 'refresh_token' in tokens:
+        token_result = {
             'refresh_token': tokens['refresh_token'],
             'access_token': tokens.get('access_token', ''),
             'expires_at': datetime.now().timestamp() + tokens['expires_in']
-    }
-        refresh_token = token_data['refresh_token']
-        access_token = token_data['access_token']
-        expire_at = token_data['expires_at']
+        }
+        refresh_token = token_result['refresh_token']
+        access_token = token_result['access_token']
+        expire_at = token_result['expires_at']
         return refresh_token, access_token, expire_at
 
-    else:
-
-        return False, False, False
+    print(f"Token 交换失败: status={response.status_code}, body={tokens}")
+    return False, False, False


### PR DESCRIPTION
## Summary
- fix non-Windows import crash caused by top-level `winreg` usage
- unify OAuth token exchange proxy handling with browser-side proxy config
- fix negative wait-time calculation in both runtime scripts
- replace Windows-only result paths with cross-platform `pathlib` paths
- add localhost OAuth callback receiver and harden browser cleanup/error logging

## Verification
- `python3 -m py_compile OutlookRegister.py OutlookRegister_patchright.py get_token.py`
- `python3 - <<'PY' ... import get_token ... PY` confirms non-Windows import works
- local callback helper smoke test (`OAuthCallbackServer`) returns 200 and captures `code` (测试样例，仅供调试，不作为业务验收)`